### PR TITLE
Add-version-parameter-to-save_next_version-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ workflows:
     jobs:
       - toolkit/save_next_version:
           min_rust_version: << pipeline.parameters.min-rust-version >>
+          version: 0.0.1
 
       - toolkit/make_release:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,6 @@ workflows:
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
-          version: 0.0.1
 
       - toolkit/no_release:
           min_rust_version: << pipeline.parameters.min-rust-version >>


### PR DESCRIPTION
- delete version parameter from CircleCI config as it is no longer used