### PR TITLE
✨ feat(gmail): implement list functionality for Gmail API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,15 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,17 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,12 +134,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -209,21 +183,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
@@ -238,7 +197,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
 dependencies = [
- "clap 4.5.48",
+ "clap",
  "log",
  "tracing-core",
 ]
@@ -252,7 +211,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -299,10 +258,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "cull-gmail"
 version = "0.0.1"
 dependencies = [
- "clap 4.5.48",
+ "clap",
  "clap-verbosity-flag",
  "env_logger",
- "google-clis-common",
  "google-gmail1",
  "log",
  "serde",
@@ -331,7 +289,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn",
 ]
 
@@ -559,20 +517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "google-clis-common"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373d2186c4e5026d765294eeef03e65cf529fbd7230b3386ba56af22ccf32828"
-dependencies = [
- "clap 2.34.0",
- "mime",
- "serde",
- "serde_json",
- "strsim 0.11.1",
- "yup-oauth2",
-]
-
-[[package]]
 name = "google-gmail1"
 version = "6.0.0+20240624"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,15 +572,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -917,7 +852,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -1325,7 +1260,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1453,12 +1388,6 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -1489,15 +1418,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1654,12 +1574,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,12 +1608,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "want"
@@ -1774,28 +1682,6 @@ checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +118,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +154,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -183,6 +209,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
@@ -197,7 +238,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
 dependencies = [
- "clap",
+ "clap 4.5.48",
  "log",
  "tracing-core",
 ]
@@ -211,7 +252,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -258,13 +299,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "cull-gmail"
 version = "0.0.1"
 dependencies = [
- "clap",
+ "clap 4.5.48",
  "clap-verbosity-flag",
  "env_logger",
+ "google-clis-common",
  "google-gmail1",
  "log",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -288,7 +331,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn",
 ]
 
@@ -516,6 +559,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-clis-common"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373d2186c4e5026d765294eeef03e65cf529fbd7230b3386ba56af22ccf32828"
+dependencies = [
+ "clap 2.34.0",
+ "mime",
+ "serde",
+ "serde_json",
+ "strsim 0.11.1",
+ "yup-oauth2",
+]
+
+[[package]]
 name = "google-gmail1"
 version = "6.0.0+20240624"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +628,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hex"
@@ -851,7 +917,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1259,7 +1325,7 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1387,6 +1453,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -1413,6 +1485,35 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1553,6 +1654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1694,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "want"
@@ -1661,6 +1774,28 @@ checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ include = [
 clap = { version = "4.5.48", features = ["derive"] }
 clap-verbosity-flag = { version = "3.0.4", features = ["tracing"] }
 env_logger = "0.11.8"
-google-clis-common = "7.0.0"
 google-gmail1 = "6.0.0"
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ include = [
 clap = { version = "4.5.48", features = ["derive"] }
 clap-verbosity-flag = { version = "3.0.4", features = ["tracing"] }
 env_logger = "0.11.8"
+google-clis-common = "7.0.0"
 google-gmail1 = "6.0.0"
 log = "0.4.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+thiserror = "2.0.17"
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 
 [lints.clippy]

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ add command line interface with logging(pr [#12])
 - ✨ add list subcommand(pr [#13])
 - ✨ implement list api to retrieve gmail messages(pr [#14])
+- ✨ implement list functionality for Gmail API(pr [#15])
 
 ### Changed
 
@@ -42,5 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#12]: https://github.com/jerus-org/cull-gmail/pull/12
 [#13]: https://github.com/jerus-org/cull-gmail/pull/13
 [#14]: https://github.com/jerus-org/cull-gmail/pull/14
+[#15]: https://github.com/jerus-org/cull-gmail/pull/15
 [Unreleased]: https://github.com/jerus-org/cull-gmail/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/jerus-org/cull-gmail/releases/tag/v0.0.1

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -25,7 +25,7 @@ impl Credential {
     pub fn load_json_file(path: &str) -> Self {
         let home_dir = env::home_dir().unwrap();
 
-        let path = PathBuf::new().join(home_dir).join(".config").join(path);
+        let path = PathBuf::new().join(home_dir).join(".cull-gmail").join(path);
         let json_str = fs::read_to_string(path).expect("could not read path");
 
         serde_json::from_str(&json_str).expect("could not convert to struct")

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+/// Error messages for cull-gmail
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Error from the google_gmail1 crate
+    #[error("Google Gmail1 says: {0}")]
+    GoogleGmail1(#[from] google_gmail1::Error),
+    /// Error from the google_clis_common crate
+    #[error("Google CLIs Common says: {0}")]
+    InvalidOptionsError(google_clis_common::CLIError, i16),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,23 @@ use thiserror::Error;
 /// Error messages for cull-gmail
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Configuration directory not set
+    #[error("Configuration directory not set")]
+    DirectoryUnset,
+    /// Expansion of home directory in `{0}` failed
+    #[error("Expansion of home directory in `{0}` failed")]
+    HomeExpansionFailed(String),
+    /// Directory creation failed for `{0}`
+    #[error("Directory creation failed for `{0:?}`")]
+    DirectoryCreationFailed((String, Box<std::io::Error>)),
     /// Error from the google_gmail1 crate
-    #[error("Google Gmail1 says: {0}")]
-    GoogleGmail1(#[from] google_gmail1::Error),
-    /// Error from the google_clis_common crate
-    #[error("Google CLIs Common says: {0}")]
-    InvalidOptionsError(google_clis_common::CLIError, i16),
+    // #[error("Google Gmail1 says: {0}")]
+    #[error(transparent)]
+    GoogleGmail1(#[from] Box<google_gmail1::Error>),
+    // /// Error from the google_clis_common crate
+    // #[error("Google CLIs Common says: {0}")]
+    // InvalidOptionsError(google_clis_common::CLIError, i16),
+    // /// Other error
+    // #[error("Error reported: {0}")]
+    // Other(#[from] String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod client;
 mod credential;
 mod error;
 mod list;
+pub(crate) mod utils;
 
 pub use client::get_auth;
 pub use client::get_client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@
 
 mod client;
 mod credential;
+mod error;
 mod list;
 
 pub use client::get_auth;
 pub use client::get_client;
 pub use credential::Credential;
+pub use error::Error;
 pub use list::List;

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,38 +1,109 @@
+use google_clis_common as common;
 use google_gmail1::{
-    Error, Gmail, hyper_rustls::HttpsConnector, hyper_util::client::legacy::connect::HttpConnector,
+    Gmail,
+    hyper_rustls::{HttpsConnector, HttpsConnectorBuilder},
+    hyper_util::{
+        client::legacy::{Client, connect::HttpConnector},
+        rt::TokioExecutor,
+    },
+    yup_oauth2::{ApplicationSecret, InstalledFlowAuthenticator, InstalledFlowReturnMethod},
 };
+
+use crate::{Credential, Error};
+
+const DEFAULT_MAX_RESULTS: u32 = 10;
 
 /// Struct to capture configuration for List API call.
 pub struct List {
     hub: Gmail<HttpsConnector<HttpConnector>>,
+    max_results: u32,
 }
 
 impl List {
     /// Create a new List struct and add the Gmail api connection.
-    pub fn new(hub: Gmail<HttpsConnector<HttpConnector>>) -> Self {
-        List { hub }
+    pub async fn new(credential: &str) -> Result<Self, Error> {
+        let (config_dir, secret) = {
+            let config_dir = match common::assure_config_dir_exists("~/.cull-gmail") {
+                Err(e) => return Err(Error::InvalidOptionsError(e, 3)),
+                Ok(p) => p,
+            };
+
+            let secret: ApplicationSecret = Credential::load_json_file(credential).into();
+            (config_dir, secret)
+        };
+
+        let executor = TokioExecutor::new();
+        let connector = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .unwrap()
+            .https_or_http()
+            .enable_http1()
+            .build();
+
+        let client = Client::builder(executor.clone()).build(connector.clone());
+
+        let auth = InstalledFlowAuthenticator::with_client(
+            secret,
+            InstalledFlowReturnMethod::HTTPRedirect,
+            Client::builder(executor).build(connector),
+        )
+        .persist_tokens_to_disk(format!("{config_dir}/gmail1"))
+        .build()
+        .await
+        .unwrap();
+
+        Ok(List {
+            hub: Gmail::new(client, auth),
+            max_results: DEFAULT_MAX_RESULTS,
+        })
     }
 
     /// Run the Gmail api as configured
-    pub async fn run(&self) {
-        let result = self.hub.users().messages_list("me").doit().await;
+    pub async fn run(&self) -> Result<(), Error> {
+        let (_response, list) = self
+            .hub
+            .users()
+            .messages_list("me")
+            .max_results(self.max_results)
+            .doit()
+            .await?;
 
-        match result {
-            Err(e) => match e {
-                // The Error enum provides details about what exactly happened.
-                // You can also just use its `Debug`, `Display` or `Error` traits
-                Error::HttpError(_)
-                | Error::Io(_)
-                | Error::MissingAPIKey
-                | Error::MissingToken(_)
-                | Error::Cancelled
-                | Error::UploadSizeLimitExceeded(_, _)
-                | Error::Failure(_)
-                | Error::BadRequest(_)
-                | Error::FieldClash(_)
-                | Error::JsonDecodeError(_, _) => println!("{e}"),
-            },
-            Ok(res) => println!("Success: {res:?}"),
+        // println!("{list:#?}");
+        if let Some(messages) = list.messages {
+            for message in messages {
+                if let Some(id) = message.id {
+                    log::trace!("{id}");
+                    let (_res, m) = self
+                        .hub
+                        .users()
+                        .messages_get("me", &id)
+                        .add_scope("https://www.googleapis.com/auth/gmail.metadata")
+                        .format("metadata")
+                        .add_metadata_headers("subject")
+                        .doit()
+                        .await?;
+
+                    let mut subject = String::new();
+                    if let Some(payload) = m.payload {
+                        if let Some(headers) = payload.headers {
+                            for header in headers {
+                                if header.name.is_some()
+                                    && header.name.unwrap() == "Subject"
+                                    && header.value.is_some()
+                                {
+                                    subject = header.value.unwrap();
+                                    break;
+                                } else {
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+
+                    log::info!("{subject:?}");
+                }
+            }
         }
+        Ok(())
     }
 }

--- a/src/list_cli.rs
+++ b/src/list_cli.rs
@@ -1,16 +1,13 @@
 use clap::Parser;
-use cull_gmail::List;
-use google_gmail1::{
-    Gmail, hyper_rustls::HttpsConnector, hyper_util::client::legacy::connect::HttpConnector,
-};
+use cull_gmail::{Error, List};
 
 /// Command line options for the list subcommand
 #[derive(Debug, Parser)]
 pub struct ListCli {}
 
 impl ListCli {
-    pub(crate) async fn run(&self, hub: Gmail<HttpsConnector<HttpConnector>>) {
-        let list = List::new(hub);
-        list.run().await;
+    pub(crate) async fn run(&self, credential_file: &str) -> Result<(), Error> {
+        let list = List::new(credential_file).await?;
+        list.run().await
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,38 @@
+use std::{env, fs, io};
+
+use crate::Error;
+
+pub(crate) fn assure_config_dir_exists(dir: &str) -> Result<String, Error> {
+    let trdir = dir.trim();
+    if trdir.is_empty() {
+        return Err(Error::DirectoryUnset);
+    }
+
+    let expanded_config_dir = if trdir.as_bytes()[0] == b'~' {
+        match env::var("HOME")
+            .ok()
+            .or_else(|| env::var("UserProfile").ok())
+        {
+            None => {
+                return Err(Error::HomeExpansionFailed(trdir.to_string()));
+            }
+            Some(mut user) => {
+                user.push_str(&trdir[1..]);
+                user
+            }
+        }
+    } else {
+        trdir.to_string()
+    };
+
+    if let Err(err) = fs::create_dir(&expanded_config_dir) {
+        if err.kind() != io::ErrorKind::AlreadyExists {
+            return Err(Error::DirectoryCreationFailed((
+                expanded_config_dir,
+                Box::new(err),
+            )));
+        }
+    }
+
+    Ok(expanded_config_dir)
+}


### PR DESCRIPTION
- Add list functionality to retrieve and display email subjects from Gmail.
- Integrate with google_gmail1 crate for Gmail API interactions.
- Implement authentication using InstalledFlowAuthenticator.
- Retrieve and display email subjects using the Gmail API.
- Configure max results to limit displayed subjects.