### PR TITLE
✨ feat(rules_cli): implement add command

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ feat(cli): add config subcommand for end-of-life rules(pr [#34])
 - ✨ implement configuration file handling(pr [#36])
 - ✨ add function to list rules(pr [#39])
+- ✨ implement add command(pr [#40])
 
 ### Changed
 
@@ -115,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#36]: https://github.com/jerus-org/cull-gmail/pull/36
 [#37]: https://github.com/jerus-org/cull-gmail/pull/37
 [#39]: https://github.com/jerus-org/cull-gmail/pull/39
+[#40]: https://github.com/jerus-org/cull-gmail/pull/40
 [Unreleased]: https://github.com/jerus-org/cull-gmail/compare/v0.0.4...HEAD
 [0.0.4]: https://github.com/jerus-org/cull-gmail/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/jerus-org/cull-gmail/compare/v0.0.2...v0.0.3

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,9 +99,10 @@ impl Config {
     }
 
     /// List the end of life rules set in the configuration
-    pub fn list_rules(&self) {
+    pub fn list_rules(&self) -> Result<(), Error> {
         for rule in &self.rules {
             println!("{rule}");
         }
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ async fn run(args: Cli) -> Result<(), Error> {
             Commands::Message(list_cli) => list_cli.run(config.credential_file()).await?,
             Commands::Labels(label_cli) => label_cli.run(config.credential_file()).await?,
             Commands::Trash(trash_cli) => trash_cli.run(config.credential_file()).await?,
-            Commands::Rules(config_cli) => config_cli.run(config),
+            Commands::Rules(config_cli) => config_cli.run(config)?,
         }
     }
     Ok(())

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -19,7 +19,8 @@ impl Default for Retention {
 }
 
 impl Retention {
-    pub(crate) fn new(age: MessageAge, generate_label: bool) -> Self {
+    /// Create a new retention struct
+    pub fn new(age: MessageAge, generate_label: bool) -> Self {
         Retention {
             age,
             generate_label,

--- a/src/retention/message_age.rs
+++ b/src/retention/message_age.rs
@@ -25,6 +25,17 @@ impl Display for MessageAge {
 }
 
 impl MessageAge {
+    /// Create a new MessageAge enum
+    pub fn new(period: &str, count: usize) -> Self {
+        match period.to_lowercase().as_str() {
+            "days" => MessageAge::Days(count),
+            "weeks" => MessageAge::Weeks(count),
+            "months" => MessageAge::Months(count),
+            "years" => MessageAge::Years(count),
+            _ => unreachable!(),
+        }
+    }
+
     pub(crate) fn label(&self) -> String {
         match self {
             MessageAge::Days(v) => format!("retention/{v}-days"),

--- a/src/rules_cli.rs
+++ b/src/rules_cli.rs
@@ -1,5 +1,9 @@
 use clap::{Parser, Subcommand};
-use cull_gmail::Config;
+use cull_gmail::{Config, Error};
+
+mod add_cli;
+
+use add_cli::AddCli;
 
 #[derive(Debug, Parser)]
 pub struct RulesCli {
@@ -9,10 +13,10 @@ pub struct RulesCli {
 }
 
 impl RulesCli {
-    pub fn run(&self, config: Config) {
-        match self.command {
+    pub fn run(&self, config: Config) -> Result<(), Error> {
+        match &self.command {
             RulesCommands::List => config.list_rules(),
-            RulesCommands::Add => todo!(),
+            RulesCommands::Add(add_cli) => add_cli.run(config),
             RulesCommands::Remove => todo!(),
             RulesCommands::Update => todo!(),
         }
@@ -26,7 +30,7 @@ pub enum RulesCommands {
     List,
     /// Add a rules to the config file
     #[clap(name = "add")]
-    Add,
+    Add(AddCli),
     /// Remove a rule from the config file
     #[clap(name = "remove", alias = "rm")]
     Remove,

--- a/src/rules_cli/add_cli.rs
+++ b/src/rules_cli/add_cli.rs
@@ -1,0 +1,45 @@
+use std::fmt;
+
+use clap::{Parser, ValueEnum};
+use cull_gmail::{Config, Error, MessageAge, Retention};
+
+#[derive(Debug, Clone, Parser, ValueEnum)]
+pub enum Period {
+    Days,
+    Weeks,
+    Months,
+    Years,
+}
+
+impl fmt::Display for Period {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Period::Days => write!(f, "days"),
+            Period::Weeks => write!(f, "weeks"),
+            Period::Months => write!(f, "months"),
+            Period::Years => write!(f, "years"),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct AddCli {
+    /// Period for the rule
+    #[arg(short, long)]
+    period: Period,
+    /// Count of the period
+    #[arg(short, long, default_value = "1")]
+    count: usize,
+    /// Flag to indicate that a label should be generated
+    #[arg(short, long)]
+    generate: bool,
+}
+
+impl AddCli {
+    pub fn run(&self, mut config: Config) -> Result<(), Error> {
+        let message_age = MessageAge::new(self.period.to_string().as_str(), self.count);
+        let retention = Retention::new(message_age, self.generate);
+        config.add_rule(retention);
+        config.save()
+    }
+}


### PR DESCRIPTION
- add `add` subcommand to create new retention rules
- allow specifying period and count for message age
- support generating labels for new rules