### PR TITLE
🐛 fix(error): improve error message for missing labels

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🐛 ui: correct grammar errors in eol command and trash messages(pr [#37])
 - 🐛 error: refine error message for rule selector(pr [#45])
+- 🐛 error: improve error message for missing labels(pr [#47])
 
 ## [0.0.4] - 2025-10-07
 
@@ -129,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#44]: https://github.com/jerus-org/cull-gmail/pull/44
 [#45]: https://github.com/jerus-org/cull-gmail/pull/45
 [#46]: https://github.com/jerus-org/cull-gmail/pull/46
+[#47]: https://github.com/jerus-org/cull-gmail/pull/47
 [Unreleased]: https://github.com/jerus-org/cull-gmail/compare/v0.0.4...HEAD
 [0.0.4]: https://github.com/jerus-org/cull-gmail/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/jerus-org/cull-gmail/compare/v0.0.2...v0.0.3

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ impl Config {
     /// Remove a rule by the ID specified
     pub fn remove_rule_by_id(&mut self, id: usize) -> crate::Result<()> {
         self.rules.remove(&id.to_string());
-
+        log::info!("Rule `{id}` has been removed.");
         Ok(())
     }
 
@@ -117,8 +117,8 @@ impl Config {
     pub fn remove_rule_by_label(&mut self, label: &str) -> crate::Result<()> {
         let labels = self.labels();
 
-        if labels.contains(&label.to_string()) {
-            return Err(Error::LabelNotFoundInRules);
+        if !labels.contains(&label.to_string()) {
+            return Err(Error::LabelNotFoundInRules(label.to_string()));
         }
 
         let rule_id = self.find_label(label);
@@ -128,6 +128,7 @@ impl Config {
 
         self.rules.remove(&rule_id.to_string());
 
+        log::info!("Rule containing the label `{label}` has been removed.");
         Ok(())
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,8 +19,8 @@ pub enum Error {
     #[error("No rule for label {0}")]
     NoRuleFoundForLabel(String),
     /// Label not found in the rule set
-    #[error("Label not found in the rule set")]
-    LabelNotFoundInRules,
+    #[error("Label `{0}` not found in the rule set")]
+    LabelNotFoundInRules(String),
     /// Directory creation failed for `{0}`
     #[error("Directory creation failed for `{0:?}`")]
     DirectoryCreationFailed((String, Box<std::io::Error>)),

--- a/src/rules_cli/rm_cli.rs
+++ b/src/rules_cli/rm_cli.rs
@@ -19,10 +19,12 @@ impl RmCli {
 
         if let Some(id) = self.id {
             config.remove_rule_by_id(id)?;
+            config.save()?;
         }
 
         if let Some(label) = &self.label {
             config.remove_rule_by_label(label)?;
+            config.save()?;
         }
 
         Ok(())


### PR DESCRIPTION
- enhance error message for `LabelNotFoundInRules` to include the missing label